### PR TITLE
Class fix for responsive theme

### DIFF
--- a/src/AdvancedFlagging.ts
+++ b/src/AdvancedFlagging.ts
@@ -767,7 +767,7 @@ async function Setup() {
                 const content = $(review.content);
                 postDetails[postId] = {
                     questionTime: parseDate($('.post-signature.owner .user-action-time span', content).attr('title')),
-                    answerTime: parseDate($('.post-signature .user-action-time span', content).attr('title'))
+                    answerTime: parseDate($('.user-info .user-action-time span', content).attr('title'))
                 };
             };
 


### PR DESCRIPTION
See related PR [here](https://github.com/SOBotics/UserscriptTools/pull/2).

This uses the class `.user-info` class as opposed to the `.post-signature` class, as that is not present on the responsive (Mobile design).

As the sotools need to be updated/merged in, I'll let you handle rebuilding for dist.