### PR TITLE
Update selector for upvoting comments

### DIFF
--- a/src/AdvancedFlagging.ts
+++ b/src/AdvancedFlagging.ts
@@ -319,7 +319,7 @@ async function BuildFlaggingDialog(element: JQuery,
                                     }
 
                                     if (text === strippedComment) {
-                                        jEle.closest('li').find('a.comment-up.comment-up-off').trigger('click');
+                                        jEle.closest('li').find('button.comment-up.comment-up-off').trigger('click');
                                     }
                                 });
                             }


### PR DESCRIPTION
After a UI change in the comment section, the upvote and flagicon are now `<button>` instead of `<a>`.