### PR TITLE
Exclude SEDE from the userscript.

### DIFF
--- a/src/UserScriptDeclaration.js
+++ b/src/UserScriptDeclaration.js
@@ -15,6 +15,7 @@
 // @exclude      *://chat.stackoverflow.com/*
 // @exclude      *://blog.stackoverflow.com/*
 // @exclude      *://*.area51.stackexchange.com/*
+// @exclude      *://data.stackexchange.com/*
 // @require      https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.4/require.min.js
 // @grant        GM_xmlhttpRequest
 // @grant        GM_listValues


### PR DESCRIPTION
When using SEDE Advanced Flagging is throwing a lot of errors. It does not need to be executed on data.stackexchange.com