### PR TITLE
Replace Sentinel links with FMS links

### DIFF
--- a/src/UserscriptTools/NattyApi.ts
+++ b/src/UserscriptTools/NattyApi.ts
@@ -99,7 +99,7 @@ export class NattyAPI extends Reporter {
     public override getIcon(): HTMLDivElement {
         return this.createBotIcon(
             this.wasReported()
-                ? `//sentinel.erwaysoftware.com/posts/aid/${this.id}`
+                ? `//logs.sobotics.org/Natty/${this.id}.html`
                 : ''
         );
     }


### PR DESCRIPTION
Sentinel has been replaced by FMS (sentinel links now error out). Clicking the Natty icon next to posts that Natty has reported go to Sentinel links, which don't work. This PR makes them go to FMS instead.