### PR TITLE
#373: error handling for CopyPastor returning errors

### DIFF
--- a/dist/AdvancedFlagging.user.js
+++ b/dist/AdvancedFlagging.user.js
@@ -1685,18 +1685,31 @@ ${responseText}`);
     chat = new ChatApi();
     feedbackMessage;
     reportMessage;
-    static getAllNattyIds(ids) {
+    static async getAllNattyIds(ids) {
       const postIds2 = (ids ?? page.getAllPostIds(false, false)).join(",");
-      if (!Page.isStackOverflow || !postIds2) return Promise.resolve();
+      if (!Page.isStackOverflow || !postIds2) return;
+      try {
+        this.nattyIds = await this.requestNattyIds(postIds2);
+      } catch (error) {
+        displayToaster("Could not connect to Natty.", "danger");
+        console.error(error);
+      }
+    }
+    static requestNattyIds(postIds2) {
       return new Promise((resolve, reject) => {
         GM_xmlhttpRequest({
           method: "GET",
           url: `${nattyFeedbackUrl}${postIds2}`,
-          onload: ({ status, responseText }) => {
-            if (status !== 200) reject();
+          onload: ({ status, responseText, statusText }) => {
+            if (status !== 200) {
+              reject(`Bad response from ${nattyFeedbackUrl}.
+Status: ${status} ${statusText}.
+Response was:
+${responseText}`);
+              return;
+            }
             const result = JSON.parse(responseText);
-            this.nattyIds = result.items.map(({ name }) => Number(name));
-            resolve();
+            resolve(result.items.map(({ name }) => Number(name)));
           },
           onerror: () => reject()
         });

--- a/dist/AdvancedFlagging.user.js
+++ b/dist/AdvancedFlagging.user.js
@@ -1176,7 +1176,14 @@
           method: "GET",
           url,
           timeout: 1500,
-          onload: ({ responseText }) => {
+          onload: ({ responseText, status, statusText }) => {
+            if (status !== 200) {
+              reject(`Bad response from ${this.server}.
+Status: ${status} ${statusText}.
+Response was:
+${responseText}`);
+              return;
+            }
             const response = JSON.parse(responseText);
             if (response.status === "failure") return;
             response.posts.forEach((item) => {

--- a/src/UserscriptTools/CopyPastorAPI.ts
+++ b/src/UserscriptTools/CopyPastorAPI.ts
@@ -73,7 +73,12 @@ export class CopyPastorAPI extends Reporter {
                 method: 'GET',
                 url,
                 timeout: 1500,
-                onload: ({ responseText }) => {
+                onload: ({ responseText, status, statusText }) => {
+                    if (status !== 200) {
+                        reject(`Bad response from ${this.server}.\nStatus: ${status} ${statusText}.\nResponse was:\n${responseText}`);
+                        return;
+                    }
+
                     const response = JSON.parse(responseText) as CopyPastorFindTargetResponse;
 
                     if (response.status === 'failure') return;

--- a/src/UserscriptTools/NattyApi.ts
+++ b/src/UserscriptTools/NattyApi.ts
@@ -1,6 +1,6 @@
 import { ChatApi } from './ChatApi';
 import { AllFeedbacks } from '../shared';
-import { page } from '../AdvancedFlagging';
+import { displayToaster, page } from '../AdvancedFlagging';
 
 import WebsocketUtils from './WebsocketUtils';
 import Reporter from './Reporter';
@@ -41,22 +41,33 @@ export class NattyAPI extends Reporter {
         this.reportMessage = `@Natty report https://stackoverflow.com/a/${this.id}`;
     }
 
-    public static getAllNattyIds(ids?: number[]): Promise<void> {
+    public static async getAllNattyIds(ids?: number[]): Promise<void> {
         const postIds = (ids ?? page.getAllPostIds(false, false)).join(',');
 
-        if (!Page.isStackOverflow || !postIds) return Promise.resolve();
+        if (!Page.isStackOverflow || !postIds) return;
 
-        return new Promise<void>((resolve, reject) => {
+        try {
+            this.nattyIds = await this.requestNattyIds(postIds);
+        } catch (error) {
+            displayToaster('Could not connect to Natty.', 'danger');
+            console.error(error);
+        }
+    }
+
+    private static requestNattyIds(postIds: string): Promise<number[]> {
+        return new Promise<number[]>((resolve, reject) => {
             GM_xmlhttpRequest({
                 method: 'GET',
                 url: `${nattyFeedbackUrl}${postIds}`,
-                onload: ({ status, responseText }) => {
-                    if (status !== 200) reject();
+                onload: ({ status, responseText, statusText }) => {
+                    if (status !== 200) {
+                        reject(`Bad response from ${nattyFeedbackUrl}.\nStatus: ${status} ${statusText}.\nResponse was:\n${responseText}`);
+                        return;
+                    }
 
                     const result = JSON.parse(responseText) as NattyFeedback;
-                    this.nattyIds = result.items.map(({ name }) => Number(name));
 
-                    resolve();
+                    resolve(result.items.map(({ name }) => Number(name)));
                 },
                 onerror: () => reject()
             });


### PR DESCRIPTION
Addresses #373 by adding a check for success for requests to Copypastor before parsing the response as JSON.

In addition, refactored the Natty request code and added the same type of check for when request to `https://logs.sobotics.org` fails.